### PR TITLE
fix missing mip maps, support BC4U and RGBA_8888, PNG export and support 2DArray

### DIFF
--- a/HzdTextureExplorer.sln
+++ b/HzdTextureExplorer.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31624.102
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HzdTextureExplorer", "HzdTextureExplorer\HzdTextureExplorer.csproj", "{67D89072-C891-443C-9B44-FE9071CFE9D6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HzdTextureExplorer", "HzdTextureExplorer\HzdTextureExplorer.csproj", "{07F1B53A-655F-4666-95F9-92C69B57302A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,15 +11,15 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{67D89072-C891-443C-9B44-FE9071CFE9D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{67D89072-C891-443C-9B44-FE9071CFE9D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{67D89072-C891-443C-9B44-FE9071CFE9D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{67D89072-C891-443C-9B44-FE9071CFE9D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07F1B53A-655F-4666-95F9-92C69B57302A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07F1B53A-655F-4666-95F9-92C69B57302A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07F1B53A-655F-4666-95F9-92C69B57302A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07F1B53A-655F-4666-95F9-92C69B57302A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {419F0899-3707-488E-ABC3-753865F99EB6}
+		SolutionGuid = {C2EB33D6-F361-4D25-BF85-F0C15B440972}
 	EndGlobalSection
 EndGlobal

--- a/HzdTextureExplorer/DdsImage.cs
+++ b/HzdTextureExplorer/DdsImage.cs
@@ -34,7 +34,7 @@ namespace HzdTextureExplorer
 
         public DDSImage(string file)
         {
-            m_image = Pfim.Pfim.FromFile(file);
+            m_image = Pfim.Pfimage.FromFile(file);
             Process();
         }
 
@@ -71,6 +71,10 @@ namespace HzdTextureExplorer
             else if (m_image.Format == Pfim.ImageFormat.Rgb24)
             {
                 Unpack<Bgr24>();
+            }
+            else if (m_image.Format == Pfim.ImageFormat.Rgb8)
+            {
+                Unpack<L8>();
             }
             else
                 throw new Exception("Unsupported pixel format (" + m_image.Format + ")");

--- a/HzdTextureExplorer/DdsImage.cs
+++ b/HzdTextureExplorer/DdsImage.cs
@@ -96,7 +96,7 @@ namespace HzdTextureExplorer
         {
             var encoder = new PngEncoder
             {
-                ColorType = PngColorType.Rgb,
+                ColorType = PngColorType.RgbWithAlpha,
                 BitDepth = PngBitDepth.Bit8,
                 TransparentColorMode = PngTransparentColorMode.Preserve
             };

--- a/HzdTextureExplorer/DdsImage.cs
+++ b/HzdTextureExplorer/DdsImage.cs
@@ -77,14 +77,7 @@ namespace HzdTextureExplorer
 
             m_stream = new MemoryStream();
 
-            var encoder = new PngEncoder
-            {
-                ColorType = PngColorType.Rgb,
-                BitDepth = PngBitDepth.Bit8,
-                TransparentColorMode = PngTransparentColorMode.Preserve
-            };
-
-            m_unpacked.SaveAsPng(m_stream, encoder);
+            WritePng(m_stream);
 
             m_bitmap = new BitmapImage();
             m_bitmap.BeginInit();
@@ -95,6 +88,17 @@ namespace HzdTextureExplorer
             m_bitmap.EndInit();
         }
 
+        public void WritePng(Stream stream)
+        {
+            var encoder = new PngEncoder
+            {
+                ColorType = PngColorType.Rgb,
+                BitDepth = PngBitDepth.Bit8,
+                TransparentColorMode = PngTransparentColorMode.Preserve
+            };
+
+            m_unpacked.SaveAsPng(stream, encoder);
+        }
         public void WriteTga(Stream stream)
         {
             var encoder = new TgaEncoder

--- a/HzdTextureExplorer/HzDCore.cs
+++ b/HzdTextureExplorer/HzDCore.cs
@@ -146,7 +146,7 @@ namespace HzdTextureExplorer
 
         public Stream OpenImage(ImageData image)
         {
-            MemoryStream stream = new MemoryStream((int)(148 + image.StreamSize));
+            MemoryStream stream = new MemoryStream((int)(148 + image.StreamSize + image.EmbeddedSize));
             BinaryWriter writer = new BinaryWriter(stream);
 
             ReadImage(image, writer);

--- a/HzdTextureExplorer/HzDCore.cs
+++ b/HzdTextureExplorer/HzDCore.cs
@@ -299,7 +299,7 @@ namespace HzdTextureExplorer
                 writer.Write((uint)Pfim.D3D10ResourceDimension.D3D10_RESOURCE_DIMENSION_TEXTURE2D);
                 writer.Write(dummy); // misc flag
                 writer.Write((uint)slices>0?slices:1); // array size
-                writer.Write((uint)8); // alpha mode
+                writer.Write((uint)1); // straight alpha mode
             }
         }
 

--- a/HzdTextureExplorer/HzDCore.cs
+++ b/HzdTextureExplorer/HzDCore.cs
@@ -124,7 +124,7 @@ namespace HzdTextureExplorer
             {
                 writer.Write(ReadStreamData(image.StreamStart, image.StreamLength));
             }
-            else
+            if (image.HasEmbeddedData)
             {
                 writer.Write(image.EmbeddedData);
             }
@@ -422,14 +422,12 @@ namespace HzdTextureExplorer
             BC6S = 0x4A,
             BC7 = 0x4B
         };
-        byte Unknown;
         public Formats Format; // byte
         byte Unknown2;
         byte Unknown3;
 
         public ImageFormat(BinaryReader reader)
         {
-            Unknown = reader.ReadByte();
             Format = (Formats)reader.ReadByte();
             Unknown2 = reader.ReadByte();
             Unknown3 = reader.ReadByte();

--- a/HzdTextureExplorer/HzDCore.cs
+++ b/HzdTextureExplorer/HzDCore.cs
@@ -106,9 +106,18 @@ namespace HzdTextureExplorer
         public void ReadImage(ImageData image, BinaryWriter writer, bool allowFail = false)
         {
             HzDException exception = null;
+            uint height = image.Height;
+            uint slices = image.Slices;
+
+            // Pfimage, PNG and TGA not supporting layers => stack the slices vertical into one image
+            if (image.Type.Type == ImageType.Types.Texture_2DArray && writer.BaseStream.GetType() == typeof(System.IO.MemoryStream)) {
+                height *= slices;
+                slices = 1;
+            };
+
             try
             {
-                Helper.WriteDdsHeader(writer, image.Width, image.Height, image.MipMaps, image.Slices, image.Format);
+                Helper.WriteDdsHeader(writer, image.Width, height, image.MipMaps, slices, image.Format);
             }
             catch(HzDException ex)
             {

--- a/HzdTextureExplorer/HzdTextureExplorer.csproj
+++ b/HzdTextureExplorer/HzdTextureExplorer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>HzdTextureExplorer.App</StartupObject>

--- a/HzdTextureExplorer/HzdTextureExplorer.csproj
+++ b/HzdTextureExplorer/HzdTextureExplorer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>HzdTextureExplorer.App</StartupObject>
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pfim" Version="0.10.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
+    <PackageReference Include="Pfim" Version="0.11.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HzdTextureExplorer/ITexture.cs
+++ b/HzdTextureExplorer/ITexture.cs
@@ -35,6 +35,21 @@ namespace HzdTextureExplorer
         public abstract void WriteDds(string path);
         public abstract void UpdateImageData(string path);
 
+        public void WritePng(string path)
+        {
+            FileStream file = File.OpenWrite(path);
+            try
+            {
+                Image.WritePng(file);
+            }
+            catch
+            {
+                file.Close();
+                throw;
+            }
+            file.Close();
+        }
+
         public void WriteTga(string path)
         {
             FileStream file = File.OpenWrite(path);

--- a/HzdTextureExplorer/ImageData.cs
+++ b/HzdTextureExplorer/ImageData.cs
@@ -8,9 +8,9 @@ namespace HzdTextureExplorer
         private long BasePosition;
         private ulong EmbeddedPosition;
 
-        public ushort Unknown1;
+        public readonly ImageType Type;
         public ImageSize Size;
-        public ushort Slices;
+        public uint Slices;
 
         public uint MipMaps;
         public uint StreamMipMaps;
@@ -70,7 +70,7 @@ namespace HzdTextureExplorer
             if (size == 0)
                 return;
 
-            Unknown1 = reader.ReadUInt16();
+            Type = new ImageType(reader);
             Size = ImageSize.Read14bits(reader);
 
             Slices = reader.ReadUInt16();
@@ -170,6 +170,16 @@ namespace HzdTextureExplorer
                     throw new HzDException($"Invalid PixelFormat {fileDdsFormat} in dds. Expected BC3");
                 }
             }
+            else if (Format.Format == ImageFormat.Formats.BC4U)
+            {
+                if (!(
+                    header.PixelFormat.FourCC == Pfim.CompressionAlgorithm.BC4U ||
+                    (header.PixelFormat.FourCC == Pfim.CompressionAlgorithm.DX10 && dxt10Header.DxgiFormat == Pfim.DxgiFormat.BC4_UNORM)
+                    ))
+                {
+                    throw new HzDException($"Invalid PixelFormat {fileDdsFormat} in dds. Expected BC4U");
+                }
+            }
             else if (Format.Format == ImageFormat.Formats.BC5U)
             {
                 if (!(
@@ -201,6 +211,13 @@ namespace HzdTextureExplorer
                 if (header.PixelFormat.FourCC != Pfim.CompressionAlgorithm.DX10 || dxt10Header.DxgiFormat != Pfim.DxgiFormat.BC7_UNORM)
                 {
                     throw new HzDException($"Invalid PixelFormat {fileDdsFormat} in dds. Expected BC7");
+                }
+            }
+            else if (Format.Format == ImageFormat.Formats.RGBA_8888)
+            {
+                if (header.PixelFormat.FourCC != Pfim.CompressionAlgorithm.DX10 || dxt10Header.DxgiFormat != Pfim.DxgiFormat.R8G8B8A8_UNORM)
+                {
+                    throw new HzDException($"Invalid PixelFormat {fileDdsFormat} in dds. Expected RGBA_8888");
                 }
             }
             else

--- a/HzdTextureExplorer/ImageData.cs
+++ b/HzdTextureExplorer/ImageData.cs
@@ -10,9 +10,11 @@ namespace HzdTextureExplorer
 
         public ushort Unknown1;
         public ImageSize Size;
-        public ushort Unknown2;
+        public ushort Slices;
 
         public uint MipMaps;
+        public uint StreamMipMaps;
+        
 
         public byte[] Magic;
 
@@ -54,6 +56,13 @@ namespace HzdTextureExplorer
             }
         }
 
+        public bool HasEmbeddedData
+        {
+            get
+            {
+                return EmbeddedSize > 0;
+            }
+        }
 
         public ImageData(FileStream stream, BinaryReader reader, long size)
         {
@@ -64,7 +73,8 @@ namespace HzdTextureExplorer
             Unknown1 = reader.ReadUInt16();
             Size = ImageSize.Read14bits(reader);
 
-            Unknown2 = reader.ReadUInt16();
+            Slices = reader.ReadUInt16();
+            MipMaps = reader.ReadByte();
             Format = new ImageFormat(reader);
             Magic = reader.ReadBytes(4); // 0x00 0xA9 0xFF 0x00
 
@@ -80,7 +90,7 @@ namespace HzdTextureExplorer
 
             if(StreamSize > 0)
             {
-                MipMaps = reader.ReadUInt32();
+                StreamMipMaps = reader.ReadUInt32();
                 uint cacheSize = reader.ReadUInt32();
                 char[] cacheString = reader.ReadChars((int)cacheSize);
                 CacheString = new string(cacheString);
@@ -207,7 +217,7 @@ namespace HzdTextureExplorer
 
                 core.UpdateImage(this, imageData);
             }
-            else
+            if (HasEmbeddedData)
             {
                 byte[] imageData = new byte[EmbeddedSize];
                 int readBytes = file.Read(imageData, 0, (int)EmbeddedSize);

--- a/HzdTextureExplorer/ImageData.cs
+++ b/HzdTextureExplorer/ImageData.cs
@@ -116,6 +116,7 @@ namespace HzdTextureExplorer
         public void UpdateFromFile(string filename, HzDCore core)
         {
             FileStream file = File.OpenRead(filename);
+            uint arraySize = Slices>0?Slices:1;
 
             // Read header
             Pfim.DdsHeader header = new Pfim.DdsHeader(file);
@@ -125,10 +126,10 @@ namespace HzdTextureExplorer
                 // Also read dxt10 header
                 dxt10Header = new Pfim.DdsHeaderDxt10(file);
             }
-            
-            if(dxt10Header.ArraySize < Slices)
+
+            if(dxt10Header.ArraySize != arraySize)
             {
-                throw new HzDException($"Imported dds has too few slices, needs at least {Slices}. (had only {dxt10Header.ArraySize})");
+                throw new HzDException($"Array size of imported dds file don't match. Must be {arraySize}, but was {dxt10Header.ArraySize}");
             }
 
             if(header.Width != Width || header.Height != Height)

--- a/HzdTextureExplorer/ImageData.cs
+++ b/HzdTextureExplorer/ImageData.cs
@@ -125,6 +125,11 @@ namespace HzdTextureExplorer
                 // Also read dxt10 header
                 dxt10Header = new Pfim.DdsHeaderDxt10(file);
             }
+            
+            if(dxt10Header.ArraySize < Slices)
+            {
+                throw new HzDException($"Imported dds has too few slices, needs at least {Slices}. (had only {dxt10Header.ArraySize})");
+            }
 
             if(header.Width != Width || header.Height != Height)
             {
@@ -133,7 +138,7 @@ namespace HzdTextureExplorer
 
             if(header.MipMapCount < MipMaps)
             {
-                throw new HzDException($"Imported dds has too few mipsmaps, needs at least {MipMaps}. (had only {header.MipMapCount}");
+                throw new HzDException($"Imported dds has too few mipsmaps, needs at least {MipMaps}. (had only {header.MipMapCount})");
             }
 
             if (header.PixelFormat.Size != 32)

--- a/HzdTextureExplorer/MainWindow.xaml
+++ b/HzdTextureExplorer/MainWindow.xaml
@@ -22,7 +22,7 @@
 		<Grid AllowDrop="True" Drop="OnDrop">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="1*"/>
-				<ColumnDefinition Width="2*"/>
+				<ColumnDefinition Width="3*"/>
 			</Grid.ColumnDefinitions>
 			<Grid.RowDefinitions>
 				<RowDefinition Height="3*"/>
@@ -36,7 +36,32 @@
 			</ListBox>
 			<ListBox Name="Info" Grid.Column="0" Grid.Row="1">
 			</ListBox>
-			<Image Name="Preview" Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"/>
+			<DockPanel Name="dpPreview" Grid.Column="1" Grid.Row="0" Grid.RowSpan="2">
+				<DockPanel.Background>
+					<DrawingBrush TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
+						<DrawingBrush.Drawing>
+							<GeometryDrawing Brush="Lightgray" Geometry="M5,5 L0,5 0,10 5,10 5,5 10,5 10,0 5,0 Z"/>
+						</DrawingBrush.Drawing>
+					</DrawingBrush>
+				</DockPanel.Background>
+				<Grid>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="*"/>
+					</Grid.ColumnDefinitions>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="*"/>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="*"/>
+					</Grid.RowDefinitions>
+					<Border Name="brdPreview" BorderThickness="2" BorderBrush="Red" Grid.Column="1" Grid.Row="1"
+						MaxHeight="{Binding ActualHeight, ElementName=dpPreview}" MaxWidth="{Binding ActualWidth, ElementName=dpPreview}">
+						<Image Name="Preview" Source="Resources/hzd_texture_icon_256.png"
+						       VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
+					</Border>
+				</Grid>
+			</DockPanel>
 		</Grid>
     </DockPanel>
 </Window>

--- a/HzdTextureExplorer/MainWindow.xaml.cs
+++ b/HzdTextureExplorer/MainWindow.xaml.cs
@@ -166,6 +166,7 @@ namespace HzdTextureExplorer
                 dialog.FilterIndex = 1;
                 dialog.RestoreDirectory = true;
                 dialog.DefaultExt = "dds";
+                dialog.FileName = tex.Name;
                 dialog.Title = $"Export {tex.Name}";
                     
                 if(dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)

--- a/HzdTextureExplorer/MainWindow.xaml.cs
+++ b/HzdTextureExplorer/MainWindow.xaml.cs
@@ -136,6 +136,10 @@ namespace HzdTextureExplorer
             {
                 tex.WriteDds(file);
             }
+            else if(ext == ".png")
+            {
+                tex.WritePng(file);
+            }
             else if(ext == ".tga")
             {
                 tex.WriteTga(file);
@@ -158,7 +162,7 @@ namespace HzdTextureExplorer
             using(var dialog = new System.Windows.Forms.SaveFileDialog())
             {
                 dialog.InitialDirectory = m_core?.Path;
-                dialog.Filter = "Direct Draw Surfaces (*.dds)|*.dds|Targa Image File (*.tga)|*.tga";
+                dialog.Filter = "Direct Draw Surfaces (*.dds)|*.dds|PNG Image File (*.png)|*.png|Targa Image File (*.tga)|*.tga";
                 dialog.FilterIndex = 1;
                 dialog.RestoreDirectory = true;
                 dialog.DefaultExt = "dds";
@@ -190,7 +194,7 @@ namespace HzdTextureExplorer
             using(var dialog = new System.Windows.Forms.SaveFileDialog())
             {
                 dialog.InitialDirectory = m_core?.Path;
-                dialog.Filter = "Direct Draw Surfaces (*.dds)|*.dds|Targa Image File (*.tga)|*.tga";
+                dialog.Filter = "Direct Draw Surfaces (*.dds)|*.dds|PNG Image File (*.png)|*.png|Targa Image File (*.tga)|*.tga";
                 dialog.FilterIndex = 1;
                 dialog.RestoreDirectory = true;
                 dialog.DefaultExt = "dds";

--- a/HzdTextureExplorer/MainWindow.xaml.cs
+++ b/HzdTextureExplorer/MainWindow.xaml.cs
@@ -245,6 +245,7 @@ namespace HzdTextureExplorer
                         Images.Items.Add(tex);
                     }
                 }
+                Images.SelectedItem = Images.Items.GetItemAt(0);
 
             }
             catch (Exception e)


### PR DESCRIPTION
Lower level mip maps of a DDS texture are embbeded in the core file. During texture replacement the StreamData and the EmbeddedData needs to be replaced with the mip maps from the DDS image. This also means, that after modding the texture, the corresponding  core and stream file needs to be packed into a patch .bin file.
Further improvement:
  - support for exporting to PNG
  - support for BC4U and RGBA_8888
  - DDS header compatibility
  - display alpha channel
  - support for texture type 2DArray
  
  ZIP file with compiled executable attached:
  [HzdTextureExplorer.zip](https://github.com/torandi/HzDTextureExplorer/files/13458205/HzdTextureExplorer.zip)