### PR TITLE
Support alternative magic

### DIFF
--- a/HzdTextureExplorer/ImageData.cs
+++ b/HzdTextureExplorer/ImageData.cs
@@ -78,7 +78,7 @@ namespace HzdTextureExplorer
             Format = new ImageFormat(reader);
             Magic = reader.ReadBytes(4); // 0x00 0xA9 0xFF 0x00
 
-            if(!(Magic[0] == 0 && Magic[1] == 0xa9 && Magic[2] == 0xff && Magic[3] == 0x00))
+            if(!(Magic[0] == 0 && Magic[1] == 0xa9 && Magic[2] == 0xff && (Magic[3] == 0x00 || Magic[3] == 0x01)))
                 throw new HzDException("Invalid magic in texture");
 
             Hash = reader.ReadBytes(16);


### PR DESCRIPTION
Some textures in HZD seem to have a differnent magic number, where the last bytes ix 0x01 instead of 0x00.
This pacth accept now also this alternative magic number.
Attached the pre build binary with the latest changes. Build with .NET 8.0 SDK.
[HzdTextureExplorer-v0.50+mithkr-patch2.zip](https://github.com/torandi/HzDTextureExplorer/files/13801771/HzdTextureExplorer-v0.50%2Bmithkr-patch2.zip)